### PR TITLE
fix: root scss variable

### DIFF
--- a/src/components/variables.scss
+++ b/src/components/variables.scss
@@ -1,2 +1,2 @@
 $ns: 'yc-';
-$root: '#{$ns}root';
+$root: '.#{$ns}root';


### PR DESCRIPTION
Fix incorrect value used as classname selector. Current behaviour breaks view of the Tabs component.