### PR TITLE
fix: correctly show textarea resize control

### DIFF
--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -31,7 +31,8 @@ $block: '.#{$ns}text-input';
 
         &_type {
             &_textarea {
-                &:not([resize]), &[resize='none'] {
+                &:not([resize]),
+                &[resize='none'] {
                     resize: none;
                 }
                 // fix-bug(firefox): https://bugzilla.mozilla.org/show_bug.cgi?id=33654

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -31,7 +31,9 @@ $block: '.#{$ns}text-input';
 
         &_type {
             &_textarea {
-                resize: none;
+                &:not([resize]), &[resize='none'] {
+                    resize: none;
+                }
                 // fix-bug(firefox): https://bugzilla.mozilla.org/show_bug.cgi?id=33654
                 overflow-x: hidden;
 


### PR DESCRIPTION
Currently TextInput is always hiding textarea resize control, even when resize prop was specified in controlProps.
This fix modifies TextInput stylesheet so resize control will be hidden only when resize prop is missing or set to `none`.