### PR TITLE
fix: allow not to set a fixed height for non-virtualized lists

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -264,7 +264,7 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
                         ref={this.refContainer}
                         width={width}
                         height={height}
-                        itemSize={this.getItemHeight}
+                        itemSize={this.getItemHeight as (index: number) => number}
                         itemData={this.state.items}
                         itemCount={this.state.items.length}
                         // this property used to rerender items in viewport
@@ -425,8 +425,7 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
             const {items} = this.state;
             return itemHeight(items[index]);
         } else {
-            const estimatedItemHeight = virtualized ? Number(itemHeight) : itemHeight;
-            return estimatedItemHeight || DEFAULT_ITEM_HEIGHT;
+            return virtualized ? Number(itemHeight) || DEFAULT_ITEM_HEIGHT : itemHeight;
         }
     };
 }


### PR DESCRIPTION
Revert the breaking change https://github.com/yandex-cloud/uikit/commit/a3a3720fbc7960e6294a54e786e4adba11174918#diff-72874b9cecaf9f2c29fe3d4767351a1b799410f62b522a138b5e4f2fa6880171L329