### PR TITLE
fix (List): check mount status for delayed setState

### DIFF
--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -73,6 +73,15 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
     refFilter = React.createRef<HTMLInputElement | HTMLTextAreaElement>();
     refContainer = React.createRef<any>();
     blurTimer: ReturnType<typeof setTimeout> | null = null;
+    isMountedComponent = false;
+
+    componentDidMount() {
+        this.isMountedComponent = true;
+    }
+
+    componentWillUnmount() {
+        this.isMountedComponent = false;
+    }
 
     componentDidUpdate(prevProps: ListProps<T>) {
         if (this.props.items !== prevProps.items) {
@@ -333,6 +342,9 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
     };
 
     private deactivate = () => {
+        if (!this.isMountedComponent) {
+            return;
+        }
         if (this.props.deactivateOnLeave) {
             this.setState({activeItem: undefined});
         }

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -73,14 +73,9 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
     refFilter = React.createRef<HTMLInputElement | HTMLTextAreaElement>();
     refContainer = React.createRef<any>();
     blurTimer: ReturnType<typeof setTimeout> | null = null;
-    isMountedComponent = false;
-
-    componentDidMount() {
-        this.isMountedComponent = true;
-    }
 
     componentWillUnmount() {
-        this.isMountedComponent = false;
+        this.blurTimer = null;
     }
 
     componentDidUpdate(prevProps: ListProps<T>) {
@@ -342,7 +337,7 @@ export class List<T = unknown> extends React.Component<ListProps<T>, ListState<T
     };
 
     private deactivate = () => {
-        if (!this.isMountedComponent) {
+        if (!this.blurTimer) {
             return;
         }
         if (this.props.deactivateOnLeave) {


### PR DESCRIPTION
Fixed case: delayed call setState (triggered by mouseLeave) for unmounted component causes error
![image](https://user-images.githubusercontent.com/98329176/151127455-66f83d86-78be-44d7-b34e-3bcf8eaad92c.png)
