### PR TITLE
feat(DropdownMenu): change default size in DropdownMenu

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -6,8 +6,14 @@ import {PopupPlacement} from '../Popup';
 import {Button, ButtonProps} from '../Button';
 import {Icon} from '../Icon';
 import {DotsIcon} from '../icons/DotsIcon';
-import {DropdownMenuItemMixed, DropdownMenuItemAction, DropdownMenuItem} from './types';
+import {
+    DropdownMenuItemMixed,
+    DropdownMenuItemAction,
+    DropdownMenuItem,
+    DropdownMenuSize,
+} from './types';
 import {DropdownMenuPopup} from './DropdownMenuPopup';
+import {MenuProps} from '../Menu';
 
 import './DropdownMenu.scss';
 
@@ -29,6 +35,8 @@ interface DropdownMenuGeneralProps<T> {
     defaultSwitcherClassName?: string;
     /** Invoked whenever the switcher was clicked (if DropdownMenu is not disabled) */
     onSwitcherClick?: (event?: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    /** Allows to override some props for a default dropdown Menu */
+    defaultMenuProps?: MenuProps;
 
     popupClassName?: string;
     popupPlacement?: PopupPlacement;
@@ -43,6 +51,8 @@ interface DropdownMenuDefaultProps<T> {
     icon: React.ReactNode;
     onMenuToggle: () => void;
     hideOnScroll: boolean;
+    /** Size used for switcher and menu */
+    size?: DropdownMenuSize;
 }
 interface DropdownMenuInnerProps<T>
     extends DropdownMenuGeneralProps<T>,
@@ -62,6 +72,7 @@ export class DropdownMenu<T> extends React.PureComponent<
     // eslint-disable-next-line react/sort-comp
     static defaultProps: DropdownMenuDefaultProps<unknown> = {
         items: [],
+        size: 'm',
         icon: <Icon data={DotsIcon} />,
         onMenuToggle: noop,
         hideOnScroll: true,
@@ -86,6 +97,8 @@ export class DropdownMenu<T> extends React.PureComponent<
             popupClassName,
             switcherWrapperClassName,
             popupPlacement,
+            size,
+            defaultMenuProps,
             children,
         } = this.props;
 
@@ -108,6 +121,8 @@ export class DropdownMenu<T> extends React.PureComponent<
                     onClose={this.handleClose}
                     popupClassName={popupClassName}
                     placement={popupPlacement}
+                    size={size}
+                    defaultMenuProps={defaultMenuProps}
                 >
                     {children}
                 </DropdownMenuPopup>
@@ -116,12 +131,12 @@ export class DropdownMenu<T> extends React.PureComponent<
     }
 
     private renderDefaultSwitcher() {
-        const {defaultSwitcherClassName, defaultSwitcherProps, icon} = this.props;
+        const {size, defaultSwitcherClassName, defaultSwitcherProps, icon} = this.props;
 
         return (
             <Button
                 view="flat"
-                size="s"
+                size={size}
                 {...defaultSwitcherProps}
                 className={b('switcher-button', defaultSwitcherClassName)}
                 disabled={this.props.disabled}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -36,7 +36,7 @@ interface DropdownMenuGeneralProps<T> {
     /** Invoked whenever the switcher was clicked (if DropdownMenu is not disabled) */
     onSwitcherClick?: (event?: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
     /** Allows to override some props for a default dropdown Menu */
-    defaultMenuProps?: MenuProps;
+    menuProps?: MenuProps;
 
     popupClassName?: string;
     popupPlacement?: PopupPlacement;
@@ -98,7 +98,7 @@ export class DropdownMenu<T> extends React.PureComponent<
             switcherWrapperClassName,
             popupPlacement,
             size,
-            defaultMenuProps,
+            menuProps,
             children,
         } = this.props;
 
@@ -122,7 +122,7 @@ export class DropdownMenu<T> extends React.PureComponent<
                     popupClassName={popupClassName}
                     placement={popupPlacement}
                     size={size}
-                    defaultMenuProps={defaultMenuProps}
+                    menuProps={menuProps}
                 >
                     {children}
                 </DropdownMenuPopup>

--- a/src/components/DropdownMenu/DropdownMenuPopup.tsx
+++ b/src/components/DropdownMenu/DropdownMenuPopup.tsx
@@ -46,7 +46,7 @@ interface DropdownMenuPopupProps<T> {
     popupClassName: string | undefined;
     placement?: PopupPlacement;
     size?: DropdownMenuSize;
-    defaultMenuProps?: MenuProps;
+    menuProps?: MenuProps;
     children?: React.ReactNode;
 }
 
@@ -60,7 +60,7 @@ export class DropdownMenuPopup<T> extends React.PureComponent<DropdownMenuPopupP
             popupClassName,
             placement,
             size,
-            defaultMenuProps,
+            menuProps,
             children,
         } = this.props;
 
@@ -75,7 +75,7 @@ export class DropdownMenuPopup<T> extends React.PureComponent<DropdownMenuPopupP
                 {children ? (
                     children
                 ) : (
-                    <Menu className={b('menu')} size={size} {...defaultMenuProps}>
+                    <Menu className={b('menu')} size={size} {...menuProps}>
                         {filterAndFlat(items).map(this.renderMenuItem)}
                     </Menu>
                 )}

--- a/src/components/DropdownMenu/DropdownMenuPopup.tsx
+++ b/src/components/DropdownMenu/DropdownMenuPopup.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {block} from '../utils/cn';
 import {Popup, PopupPlacement} from '../Popup';
-import {Menu} from '../Menu';
+import {Menu, MenuProps} from '../Menu';
 
-import {DropdownMenuItem, DropdownMenuItemMixed} from './types';
+import {DropdownMenuItem, DropdownMenuItemMixed, DropdownMenuSize} from './types';
 
 const b = block('dropdown-menu');
 
@@ -45,12 +45,24 @@ interface DropdownMenuPopupProps<T> {
     onClose: () => void;
     popupClassName: string | undefined;
     placement?: PopupPlacement;
+    size?: DropdownMenuSize;
+    defaultMenuProps?: MenuProps;
     children?: React.ReactNode;
 }
 
 export class DropdownMenuPopup<T> extends React.PureComponent<DropdownMenuPopupProps<T>, never> {
     render() {
-        const {open, anchorRef, items, onClose, popupClassName, placement, children} = this.props;
+        const {
+            open,
+            anchorRef,
+            items,
+            onClose,
+            popupClassName,
+            placement,
+            size,
+            defaultMenuProps,
+            children,
+        } = this.props;
 
         return (
             <Popup
@@ -63,7 +75,7 @@ export class DropdownMenuPopup<T> extends React.PureComponent<DropdownMenuPopupP
                 {children ? (
                     children
                 ) : (
-                    <Menu className={b('menu')}>
+                    <Menu className={b('menu')} size={size} {...defaultMenuProps}>
                         {filterAndFlat(items).map(this.renderMenuItem)}
                     </Menu>
                 )}

--- a/src/components/DropdownMenu/README.md
+++ b/src/components/DropdownMenu/README.md
@@ -7,10 +7,12 @@
 | [items](#items)                            |`DropdownMenuItem[]`|     |[]         | Элементы выпадающего меню. |
 | data                                       |`T`            |          |           | Произвольный контекст, связанный с выпадающим меню |
 | icon                                       |`JSX node`     |          |           | JSX-фрагмент (инстанс компонента `Icon`) для переопределения дефолтной иконки `switcher`. |
+| size                                       |`DropdownMenuSize`|       |           | Size used for switcher and menu|
 | disabled                                   |`Boolean`      |          |           | Неактивное состояние дефолтной кнопки открытия меню. Состояние, при котором кнопка отображается, но недоступна для действий пользователя.|
 | switcher                                   |`JSX node`     |          |           | JSX-фрагмент для переопределения дефолтного `switcher`. |
 | switcherWrapperClassName                   |`string`       |          |           | Дополнительный className для родительского блока `switcher` |
 | defaultSwitcherProps                       |`ButtonProps`  |          |           | При использовании дефолтного `switcher` эта опция позволяет переопределить его свойства (кроме `disabled` и `className`) |
+| defaultMenuProps                           |`MenuProps`    |          |           | Allows to override the properties of the dropdown Menu |
 | defaultSwitcherClassName                   |`string`       |          |           | При использовании дефолтного `switcher` эта опция позволяет добавить к нему `className` |
 | onMenuToggle                               |`() => void`   |          |           | Функция, вызывающаяся каждый раз, когда происходит открытие/скрытие выпадающего меню. Может быть полезна для случая, когда в родительском компоненте необходимо как-то отслеживать состояние выпадающего меню (смотри исходный код демо страницы, компонент `ListExample`). |
 | onSwitcherClick                            |`(React.MouseEvent) => void`| |       | Функция, вызывающаяся при клике на `switcher` |

--- a/src/components/DropdownMenu/README.md
+++ b/src/components/DropdownMenu/README.md
@@ -12,8 +12,8 @@
 | switcher                                   |`JSX node`     |          |           | JSX-фрагмент для переопределения дефолтного `switcher`. |
 | switcherWrapperClassName                   |`string`       |          |           | Дополнительный className для родительского блока `switcher` |
 | defaultSwitcherProps                       |`ButtonProps`  |          |           | При использовании дефолтного `switcher` эта опция позволяет переопределить его свойства (кроме `disabled` и `className`) |
-| defaultMenuProps                           |`MenuProps`    |          |           | Allows to override the properties of the dropdown Menu |
 | defaultSwitcherClassName                   |`string`       |          |           | При использовании дефолтного `switcher` эта опция позволяет добавить к нему `className` |
+| menuProps                                  |`MenuProps`    |          |           | Allows to override the properties of the dropdown Menu |
 | onMenuToggle                               |`() => void`   |          |           | Функция, вызывающаяся каждый раз, когда происходит открытие/скрытие выпадающего меню. Может быть полезна для случая, когда в родительском компоненте необходимо как-то отслеживать состояние выпадающего меню (смотри исходный код демо страницы, компонент `ListExample`). |
 | onSwitcherClick                            |`(React.MouseEvent) => void`| |       | Функция, вызывающаяся при клике на `switcher` |
 | hideOnScroll                               |`Boolean`      |          |true       | Флаг, определяющий, должно ли выпадающее меню скрываться при скролле на родительских элементах. |

--- a/src/components/DropdownMenu/__stories__/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/__stories__/DropdownMenu.stories.tsx
@@ -164,5 +164,5 @@ const MenuSizeTemplate: Story = (args) => <DropdownMenu {...args} />;
 export const MenuSize = MenuSizeTemplate.bind({});
 MenuSize.args = {
     items: options,
-    defaultMenuProps: {size: 'l'},
+    menuProps: {size: 'l'},
 };

--- a/src/components/DropdownMenu/__stories__/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/__stories__/DropdownMenu.stories.tsx
@@ -150,3 +150,19 @@ LabelSwitcher.parameters = {
 };
 
 LabelSwitcher.storyName = 'Компонент смены статуса';
+
+// ----------------------------------------
+const SizeTemplate: Story = (args) => <DropdownMenu {...args} />;
+export const Size = SizeTemplate.bind({});
+Size.args = {
+    items: options,
+    size: 'xl',
+};
+
+// ----------------------------------------
+const MenuSizeTemplate: Story = (args) => <DropdownMenu {...args} />;
+export const MenuSize = MenuSizeTemplate.bind({});
+MenuSize.args = {
+    items: options,
+    defaultMenuProps: {size: 'l'},
+};

--- a/src/components/DropdownMenu/types.ts
+++ b/src/components/DropdownMenu/types.ts
@@ -13,3 +13,5 @@ export interface DropdownMenuItem<T> extends Omit<MenuItemProps, 'onClick' | 'ch
 }
 
 export type DropdownMenuItemMixed<T> = DropdownMenuItem<T> | Array<DropdownMenuItem<T>>;
+
+export type DropdownMenuSize = 's' | 'm' | 'l' | 'xl';


### PR DESCRIPTION
Adds `size` property that affects both switcher and dropdown menu sizes.
If needed, sizes for switcher and menu, can be defined separately using `defaultMenuProps`(added by this PR) and `defaultSwitcherProps` (existing property).
Changes default button size: `"s"` -> `"m"`

Сloses #107