### PR TITLE
feat: allow use layers for Dialog/Modal/Popup with different root

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -28,6 +28,7 @@ interface DialogOwnProps {
     size?: 's' | 'm' | 'l';
     'aria-label'?: string;
     'aria-labelledby'?: string;
+    container?: HTMLElement;
 }
 
 interface DialogDefaultProps {
@@ -57,6 +58,7 @@ export class Dialog extends React.Component<DialogInnerProps> {
 
     render() {
         const {
+            container,
             children,
             open,
             disableBodyScrollLock,
@@ -90,6 +92,7 @@ export class Dialog extends React.Component<DialogInnerProps> {
                 className={b('modal', modalClassName)}
                 aria-label={ariaLabel}
                 aria-labelledby={ariaLabelledBy}
+                container={container}
                 qa={qa}
             >
                 <div className={b({size, 'has-close': hasCloseButton}, className)}>

--- a/src/components/Dialog/README.md
+++ b/src/components/Dialog/README.md
@@ -23,6 +23,7 @@ Dialog component
 | hasCloseButton        | `Boolean`                                                                                      |          | `True`  | Cross icon in top right corner of dialog presence                                   |
 | aria-labelledby       | `String`                                                                                       |          |         | Id of <Dialog/> caption. Use `id` props of `<Dialog.Header/>` to set id for caption |
 | aria-label            | `String`                                                                                       |          |         | Dialog label for a11y. Prefer `aria-labelledby` if caption is visible to user       |
+| container             | `HTMLElement`                                                                                  |          |         | Container element for the dialog box                                                |
 | qa                    | `String`                                                                                       |          |         | Data-qa attribute value of modal box, in which dialog is disposed                   |
 
 ### Examples

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -26,6 +26,7 @@ export interface ModalProps extends DOMProps, LayerExtendableProps, QAProps {
      * Prefer `aria-labelledby` in case caption is visible to user
      */
     'aria-label'?: string;
+    container?: HTMLElement;
 }
 
 export type ModalCloseReason = LayerCloseReason;
@@ -48,6 +49,7 @@ export function Modal({
     className,
     'aria-labelledby': ariaLabelledBy,
     'aria-label': ariaLabel,
+    container,
     qa,
 }: ModalProps) {
     const contentRef = React.useRef<HTMLDivElement>(null);
@@ -92,7 +94,7 @@ export function Modal({
     }
 
     return (
-        <Portal>
+        <Portal container={container}>
             <div
                 data-inited={hasBeenOpen.current ? '' : undefined}
                 onAnimationEnd={handleAnimationEnd}

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {usePortalContainer} from '../utils/usePortalContainer';
 
 export interface PortalProps {
     container?: HTMLElement;
     children?: React.ReactNode;
 }
 
-export function Portal({container = document.body, children}: PortalProps) {
-    return ReactDOM.createPortal(children, container);
+export function Portal({container, children}: PortalProps) {
+    const defaultContainer = usePortalContainer();
+    return ReactDOM.createPortal(children, container ?? defaultContainer);
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -46,3 +46,5 @@ export * from './utils/useEventBroker';
 export * from './utils/useLayer';
 export * from './utils/useVirtualElementRef';
 export {Lang, configure} from './utils/configure';
+export * from './utils/PortalProvider';
+export * from './utils/usePortalContainer';

--- a/src/components/utils/PortalProvider.tsx
+++ b/src/components/utils/PortalProvider.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import type {RefObject} from 'react';
+
+export const PortalContext = React.createContext<RefObject<HTMLElement>>({current: null});
+
+PortalContext.displayName = 'PortalContext';
+
+export type PortalProviderProps = {
+    container: RefObject<HTMLElement>;
+};
+
+export const PortalProvider: React.FC<PortalProviderProps> = ({container, children}) => {
+    return <PortalContext.Provider value={container}>{children}</PortalContext.Provider>;
+};

--- a/src/components/utils/usePortalContainer.ts
+++ b/src/components/utils/usePortalContainer.ts
@@ -1,0 +1,7 @@
+import {useContext} from 'react';
+import {PortalContext} from './PortalProvider';
+
+export function usePortalContainer(): HTMLElement {
+    const context = useContext(PortalContext);
+    return context.current ?? document.body;
+}


### PR DESCRIPTION
allow display modals with a different root element. this may be useful in case when we need to determine the source of modals or place modals into container other than the document root. the default behaviour remains the same.

Example: (define the new modals root)
```
const ref = useRef();

<LayerProvider container={ref}>
  ...components where we need new root for modals
</LayerProvider>
<div ref={ref} className="modal-root"></div>
```