### PR TITLE
fix(Toaster): increase css specificity of close button mixin

### DIFF
--- a/src/components/Toaster/Toast/Toast.scss
+++ b/src/components/Toaster/Toast/Toast.scss
@@ -131,7 +131,7 @@ $block: '.#{$ns}toast';
         color: var(--yc-color-text-link);
     }
 
-    &__btn-close {
+    & &__btn-close {
         position: absolute;
         top: 16px;
         right: 16px;


### PR DESCRIPTION
 Increase css specificity of close button mixin to avoid problem like this:

![2022-05-17_12-58-30 (2)](https://user-images.githubusercontent.com/26501073/168788266-1aeaf6d9-c765-4ac9-a38f-545bf24ed851.png)

