### PR TITLE
feat: update blue color

### DIFF
--- a/src/demo/colors/Private.tsx
+++ b/src/demo/colors/Private.tsx
@@ -82,8 +82,13 @@ const renderColorTable = (theme: 'light' | 'dark') => {
         );
     };
 
-    const getClassName = (colorName: string, step: number) =>
-        `--yc-color-private-${colorName}-${step}`;
+    const getClassName = (colorName: string, step: number) => {
+        if (colorName.includes('solid')) {
+            return `--yc-color-private-${colorName.replace('-solid', '')}-${step}-solid`;
+        } else {
+            return `--yc-color-private-${colorName}-${step}`;
+        }
+    };
 
     const renderSteps = (colorName: string) => {
         return steps.map((step) => {

--- a/styles/colors/private/dark.scss
+++ b/styles/colors/private/dark.scss
@@ -27,18 +27,17 @@
     --yc-color-private-white-150-solid: rgba(76, 76, 82, 1);
     --yc-color-private-white-200-solid: rgba(87, 86, 92, 1);
 
-    --yc-color-private-blue-100: rgba(102, 179, 255, 0.15);
-    --yc-color-private-blue-150: rgba(102, 179, 255, 0.15);
-    --yc-color-private-blue-300: rgba(102, 179, 255, 0.5);
-    --yc-color-private-blue-450: rgba(102, 179, 255, 0.8);
-    --yc-color-private-blue-550: rgba(34, 132, 229, 1);
-    --yc-color-private-blue-700: rgba(61, 152, 242, 1);
-    --yc-color-private-blue-850: rgba(102, 179, 255, 1);
+    --yc-color-private-blue-100: rgba(133, 168, 255, 0.15);
+    --yc-color-private-blue-150: rgba(133, 168, 255, 0.25);
+    --yc-color-private-blue-300: rgba(133, 168, 255, 0.5);
+    --yc-color-private-blue-450: rgba(87, 126, 214, 0.8);
+    --yc-color-private-blue-550: rgba(87, 126, 214, 1);
+    --yc-color-private-blue-700: rgba(98, 146, 255, 1);
+    --yc-color-private-blue-850: rgba(133, 168, 255, 1);
 
-    --yc-color-private-blue-450-solid: rgba(36, 114, 193, 1);
-
-    --yc-color-private-blue-150-solid: rgba(59, 78, 102, 1);
-    --yc-color-private-blue-300-solid: rgba(73, 111, 153, 1);
+    --yc-color-private-blue-150-solid: rgba(67, 75, 102, 1);
+    --yc-color-private-blue-300-solid: rgba(89, 106, 153, 1);
+    --yc-color-private-blue-450-solid: rgba(79, 110, 181, 1);
 
     --yc-color-private-green-100: rgba(59, 201, 53, 0.12);
     --yc-color-private-green-150: rgba(59, 201, 53, 0.16);

--- a/styles/colors/private/light.scss
+++ b/styles/colors/private/light.scss
@@ -26,18 +26,18 @@
     --yc-color-private-black-150-solid: rgba(218, 218, 218, 1);
     --yc-color-private-black-700-solid: rgb(76, 76, 76, 1);
 
-    --yc-color-private-blue-50: rgba(2, 123, 243, 0.08);
-    --yc-color-private-blue-100: rgba(2, 123, 243, 0.14);
-    --yc-color-private-blue-300: rgba(2, 123, 243, 0.5);
-    --yc-color-private-blue-450: rgba(2, 123, 243, 0.75);
-    --yc-color-private-blue-500: rgba(2, 123, 243, 0.9);
-    --yc-color-private-blue-550: rgba(2, 123, 243, 1);
-    --yc-color-private-blue-600: rgba(2, 108, 214, 1);
-    --yc-color-private-blue-800: rgba(0, 64, 128, 1);
+    --yc-color-private-blue-50: rgba(82, 130, 255, 0.1);
+    --yc-color-private-blue-100: rgba(82, 130, 255, 0.16);
+    --yc-color-private-blue-300: rgba(82, 130, 255, 0.5);
+    --yc-color-private-blue-450: rgba(82, 130, 255, 0.75);
+    --yc-color-private-blue-500: rgba(82, 130, 255, 0.9);
+    --yc-color-private-blue-550: rgba(82, 130, 255, 1);
+    --yc-color-private-blue-600: rgba(74, 113, 214, 1);
+    --yc-color-private-blue-800: rgba(63, 87, 153, 1);
 
-    --yc-color-private-blue-50-solid: rgba(235, 244, 254, 1);
-    --yc-color-private-blue-100-solid: rgba(220, 237, 253, 1);
-    --yc-color-private-blue-450-solid: rgba(65, 156, 246, 1);
+    --yc-color-private-blue-50-solid: rgba(238, 243, 255, 1);
+    --yc-color-private-blue-100-solid: rgba(227, 235, 255, 1);
+    --yc-color-private-blue-450-solid: rgba(125, 161, 255, 1);
 
     --yc-color-private-green-50: rgba(59, 201, 53, 0.1);
     --yc-color-private-green-100: rgba(59, 201, 53, 0.14);


### PR DESCRIPTION
- Updated private blue color
- Fixed private colors showcase: it was using old solid colors naming convention



<img width="1281" alt="Screen Shot 2022-05-24 at 20 21 01" src="https://user-images.githubusercontent.com/168296/170095056-6b4f2d31-2844-4282-886d-4d6adb56182e.png">

