### PR TITLE
fix: Correct target detection for shadow-dom in function isOutsideClick

### DIFF
--- a/src/components/utils/LayerManager.ts
+++ b/src/components/utils/LayerManager.ts
@@ -89,12 +89,14 @@ class LayerManager {
     private isOutsideClick(layer: LayerConfig, event: MouseEvent) {
         const contentElements = layer.contentRefs || [];
         const {target} = event;
+        const composedPath = typeof event.composedPath === 'function' ? event.composedPath() : [];
 
         if (contentElements.length > 0) {
             const isClickOnContentElements = contentElements.some(
                 (el) =>
                     el?.current?.contains?.(target as Element) ||
-                    el?.current?.contains?.(this.mouseDownTarget),
+                    el?.current?.contains?.(this.mouseDownTarget) ||
+                    composedPath.includes(el?.current as EventTarget),
             );
 
             return !isClickOnContentElements;


### PR DESCRIPTION
# The Problem

Shadom DOM doesn't give you the correct element for `event.target` (it gives you the root for any click you make).
In our project (Yandex Nirvana) we use Shadom DOM and because of that the `isOutsideClick` function doesn't work correctly for us which messes up the `Popup` component which depends on it.

# The solution

Use the `composedPath` function which gives you the path to the element you clicked, which works even in Shadow DOM, so we can use the `Popup` element without bugs.

# For reference

You can read about the problem and solution here: https://stackoverflow.com/a/57963850/5892475.

# License Agreement

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en.