### PR TITLE
fix: relax RealTheme type for compatibility

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,7 @@
 /src/components/Text @IsaevAlexandr
 #/src/components/TextInput @dustyo-O
 /src/components/Toaster @korvin89
+/src/components/theme @resure
 # Allow everyone to publish releases
 /package.json
 /package-lock.json

--- a/src/components/theme/types.ts
+++ b/src/components/theme/types.ts
@@ -1,4 +1,4 @@
-export type RealTheme = string;
+export type RealTheme = 'light' | 'light-hc' | 'dark' | 'dark-hc' | string;
 export type ThemeType = 'light' | 'dark';
 
 export type Theme = 'system' | RealTheme;

--- a/src/components/theme/types.ts
+++ b/src/components/theme/types.ts
@@ -1,4 +1,4 @@
-export type RealTheme = 'light' | 'light-hc' | 'dark' | 'dark-hc';
+export type RealTheme = string;
 export type ThemeType = 'light' | 'dark';
 
 export type Theme = 'system' | RealTheme;


### PR DESCRIPTION
Current value of `RealTheme` type is not compatible with some existing code in services and related libraries. I think it would be better to keep it as `string` for now and move to a more narrow type in the next major release.